### PR TITLE
Access manager

### DIFF
--- a/Assets/Karting/Scenes/IntroMenu.unity
+++ b/Assets/Karting/Scenes/IntroMenu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028365, g: 0.22571431, b: 0.30692217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028335, g: 0.2257141, b: 0.30692157, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1805,7 +1805,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1741857847}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9a525735a47ce487abb70b8f1539f35d, type: 3}
+  m_Script: {fileID: 11500000, guid: 74d8a4d8f606c41279af118bbb007b7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1833309139
@@ -1917,7 +1917,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -10.106001, y: -63.388992}
+  m_AnchoredPosition: {x: -10.106001, y: -63.388977}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1834908384
@@ -2505,7 +2505,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -3.6730347, y: 50.76001}
+  m_AnchoredPosition: {x: -3.6729736, y: 50.76001}
   m_SizeDelta: {x: -107.345, y: -201.52}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2135173796

--- a/Assets/Karting/Scenes/WinScene.unity
+++ b/Assets/Karting/Scenes/WinScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731704, g: 0.13414726, b: 0.1210787, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731689, g: 0.13414702, b: 0.1210784, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1462,7 +1462,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 257.74, y: -3.4033508}
+  m_AnchoredPosition: {x: 257.74, y: -3.4033203}
   m_SizeDelta: {x: -580.52, y: -170.75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &218399283
@@ -1474,7 +1474,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 218399281}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a55ce787db3cc4cd78bdfddf4652bd7e, type: 3}
+  m_Script: {fileID: 11500000, guid: 8e05ebade75c34e1a9d9ec0a388a106d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &218399284
@@ -4424,7 +4424,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 435420345}
   m_HandleRect: {fileID: 435420344}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -5379,7 +5379,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 133, y: 23.072}
+  m_AnchoredPosition: {x: 133, y: 23.072021}
   m_SizeDelta: {x: 227.01, y: 42.501}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &986130590
@@ -6665,7 +6665,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1547798679}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1547798676}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1547798679
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9407,6 +9419,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 2075927887}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea0d32357e4a247ceaf3a84586c83fbc, type: 3}
+  m_Script: {fileID: 11500000, guid: d6216439de12c4cfda19e7601eb5ecbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Karting/Scripts/GameFlowManager.cs
+++ b/Assets/Karting/Scripts/GameFlowManager.cs
@@ -53,12 +53,16 @@ public class GameFlowManager : MonoBehaviour
     string m_SceneToLoad;
     float elapsedTimeBeforeEndScene = 0;
 
+#if UNITY_WEBGL
     [DllImport("__Internal")]
     private static extern void CompleteAction(string str);
+#endif
 
     void Start()
     {
+#if UNITY_WEBGL
         CompleteAction("Start Racing!");
+#endif
         InitializePubNub();
         if (autoFindKarts)
         {
@@ -200,7 +204,7 @@ public class GameFlowManager : MonoBehaviour
         }
     }
     
-    async void InitializePubNub()
+    void InitializePubNub()
     {
         // Use this for initialization
         if (pubnub == null)
@@ -214,11 +218,13 @@ public class GameFlowManager : MonoBehaviour
             PubNubConnection.pubnub = new PubNub(pnConfiguration);
             pubnub = PubNubConnection.pubnub;
 
-            var token = await new PubNubAccessManager().RequestToken(PubNubConnection.UserID);
-            if (token != null)
+            StartCoroutine(new PubNubAccessManager().RequestToken(PubNubConnection.UserID, (token) =>
             {
-                pubnub.SetToken(token);
-            }
+                if (token != null)
+                {
+                    pubnub.SetToken(token);
+                }
+            }));
         }
     }  
 }

--- a/Assets/Karting/Scripts/GameFlowManager.cs
+++ b/Assets/Karting/Scripts/GameFlowManager.cs
@@ -197,7 +197,7 @@ public class GameFlowManager : MonoBehaviour
         }
     }
     
-    void InitializePubNub()
+    async void InitializePubNub()
     {
         // Use this for initialization
         if (pubnub == null)
@@ -210,6 +210,12 @@ public class GameFlowManager : MonoBehaviour
             pnConfiguration.LogVerbosity = PNLogVerbosity.BODY;
             PubNubConnection.pubnub = new PubNub(pnConfiguration);
             pubnub = PubNubConnection.pubnub;
+
+            var token = await new PubNubAccessManager().RequestToken(PubNubConnection.UserID);
+            if (token != null)
+            {
+                pubnub.SetToken(token);
+            }
         }
     }  
 }

--- a/Assets/Karting/Scripts/UI/Chat.cs
+++ b/Assets/Karting/Scripts/UI/Chat.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
+using System.Text;
 using PubNubAPI;
 using TMPro;
 using UnityEngine;
@@ -37,7 +39,7 @@ public class Chat : MonoBehaviour
     //Avatars by Multiavatar: https://multiavatar.com/
     string profileGenerator = $"https://api.multiavatar.com/";
 
-    private void Awake()
+    private async void Awake()
     {         
         //Setting Objects.
         chatCanvas = GameObject.Find("Chat").GetComponent<Canvas>().transform;
@@ -58,7 +60,13 @@ public class Chat : MonoBehaviour
         pnConfiguration.LogVerbosity = PNLogVerbosity.BODY;
         PubNubConnection.pubnub = new PubNub(pnConfiguration);
         pubnub = PubNubConnection.pubnub;
-     
+
+        var token = await new PubNubAccessManager().RequestToken(PubNubConnection.UserID);
+        if (token != null)
+        {
+            pubnub.SetToken(token);
+        }
+
         // Fetch the maxMessagesToDisplay messages sent on the given PubNub channel
         pubnub.FetchMessages()
             .Channels(new List<string> { channel })

--- a/Assets/Karting/Scripts/UI/Leaderboard.cs
+++ b/Assets/Karting/Scripts/UI/Leaderboard.cs
@@ -30,10 +30,12 @@ public class Leaderboard : MonoBehaviour
     private PubNub pubnub = PubNubConnection.pubnub;
     private Button submitTime;
 
+#if UNITY_WEBGL
     [DllImport("__Internal")]
     private static extern void CompleteAction(string str);
+#endif
 
-    private async void Awake()
+    private void Awake()
     {
         //Seting-up Game Objects.
         submitTime = GameObject.Find("TimeSubmitButton").GetComponent<Button>();
@@ -51,12 +53,19 @@ public class Leaderboard : MonoBehaviour
         PubNubConnection.pubnub = new PubNub(pnConfiguration);
         pubnub = PubNubConnection.pubnub;
 
-        var token = await new PubNubAccessManager().RequestToken(PubNubConnection.UserID);
-        if (token != null)
+        StartCoroutine(new PubNubAccessManager().RequestToken(PubNubConnection.UserID, (token) =>
         {
-            pubnub.SetToken(token);
-        }
+            if (token != null)
+            {
+                pubnub.SetToken(token);
+            }
+            AccessManagerComplete();
+        }));
 
+    }
+
+    private void AccessManagerComplete()
+    {
         //Leaderboard
         MyClass fireRefreshObject = new MyClass();
         fireRefreshObject.refresh = "new user refresh";
@@ -153,7 +162,8 @@ public class Leaderboard : MonoBehaviour
                 }
             });
         submitTime.interactable = false; // Only allow submit time once.
-
+#if UNITY_WEBGL
         CompleteAction("Submit your time");
+#endif
     }
 }

--- a/Assets/Karting/Scripts/UI/Leaderboard.cs
+++ b/Assets/Karting/Scripts/UI/Leaderboard.cs
@@ -29,7 +29,7 @@ public class Leaderboard : MonoBehaviour
     private PubNub pubnub = PubNubConnection.pubnub;
     private Button submitTime;
 
-    private void Awake()
+    private async void Awake()
     {
         //Seting-up Game Objects.
         submitTime = GameObject.Find("TimeSubmitButton").GetComponent<Button>();
@@ -46,7 +46,13 @@ public class Leaderboard : MonoBehaviour
         pnConfiguration.LogVerbosity = PNLogVerbosity.BODY;
         PubNubConnection.pubnub = new PubNub(pnConfiguration);
         pubnub = PubNubConnection.pubnub;
-       
+
+        var token = await new PubNubAccessManager().RequestToken(PubNubConnection.UserID);
+        if (token != null)
+        {
+            pubnub.SetToken(token);
+        }
+
         //Leaderboard
         MyClass fireRefreshObject = new MyClass();
         fireRefreshObject.refresh = "new user refresh";

--- a/Assets/Karting/Scripts/UI/UsernameInput.cs
+++ b/Assets/Karting/Scripts/UI/UsernameInput.cs
@@ -13,9 +13,11 @@ public class UsernameInput : MonoBehaviour
 {
     private TMPro.TMP_InputField usernameInput;
     private Button startButton;
-  
+
+#if UNITY_WEBGL
     [DllImport("__Internal")]
     private static extern void CompleteAction(string str);
+#endif
 
     // Start is called before the first frame update
     void Start()
@@ -45,8 +47,9 @@ public class UsernameInput : MonoBehaviour
             //Check for potential profanity. Replace profanity with "*".
             usernameInput.text = ProfanityFilter.ReplaceProfanity(usernameInput.text);
             Player.Username = usernameInput.text;
-
+#if UNITY_WEBGL
             CompleteAction("Enter your username");
+#endif
         }
     }  
 }

--- a/Assets/Karting/Scripts/Utilities/PubNubAccessManager.cs
+++ b/Assets/Karting/Scripts/Utilities/PubNubAccessManager.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using UnityEngine;
+
+public class PubNubAccessManager
+{
+    private static readonly HttpClient client = new HttpClient();
+
+    public PubNubAccessManager()
+	{
+	}
+
+	public async Task<string> RequestToken(string UserId)
+	{
+        try
+        {
+            string TOKEN_SERVER = "https://devrel-demos-access-manager.netlify.app/.netlify/functions/api/unitykartracer";
+            var values = new Dictionary<string, string>
+            {
+                {
+                    "UUID", UserId
+                }
+            };
+            var content = new StringContent(JsonConvert.SerializeObject(values), Encoding.UTF8, "application/json");
+            var response = await client.PostAsync(TOKEN_SERVER + "/grant", content);
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var responseString = await response.Content.ReadAsStringAsync();
+                dynamic responseDynamic = JsonConvert.DeserializeObject<dynamic>(responseString);
+                var body = responseDynamic.body;
+                var token = responseDynamic.body.token;
+                return Convert.ToString(token);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.Log("Error setting Access manager token for DevRel demo");
+            Debug.Log(e);
+            return null;
+        }
+        return null;
+    }
+}
+

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -156,6 +156,19 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -639,6 +652,7 @@ PlayerSettings:
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform:
     Standalone: 3
+    WebGL: 3
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: kart-template

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you would like to build, run, and expand upon this application yourself, plea
 - [Git](https://www.atlassian.com/git/tutorials/install-git)
 - [Visual Studio](https://visualstudio.microsoft.com/vs/community/)
 - [PubNub Account](#pubnub-account) (*Free*)
+- [UI Art Package from Unity Asset Store](https://assetstore.unity.com/packages/2d/gui/icons/2d-casual-ui-hd-82080)
 
 <a href="https://dashboard.pubnub.com/signup">
 	<img alt="PubNub Signup" src="https://i.imgur.com/og5DDjf.png" width=260 height=97/>
@@ -151,12 +152,13 @@ export default (request) => {
   
 3. Open the project in Unity.
 4. In Assets > Karting > Scripts > GameConstants, replace your publish and subscribe keys with the PUBNUB_PUBLIC_KEY and PUBNUB_SUBSCRIBE_KEY constants at the bottom of the file.
-5. Run the game by File > Builds Settings > Build & Run.
-6. Enter a username. Press the play button.
-7. Play the game by controlling the kart with WASD or with the arrow keys.
-8. Once you've won the game, submit your score by clicking on the submit time button.
-9. View leaderboard updates in real-time.
-10. Chat with others in the lobby chat.
+5. Import the 2D Casual UI HD Art UI Package described in the pre-requisites earlier. You can either do this by clicking on "Open in Unity" in the asset store and importing the package in your application or by searching for the package in Unity via Window > Package Manager > My Assets > Select the asset and import.
+6. Run the game by File > Builds Settings > Build & Run.
+7. Enter a username. Press the play button.
+8. Play the game by controlling the kart with WASD or with the arrow keys.
+9. Once you've won the game, submit your score by clicking on the submit time button.
+10. View leaderboard updates in real-time.
+11. Chat with others in the lobby chat.
 
 ## Links
 - Demo Link: https://www.pubnub.com/demos/unity-pubnubprix/


### PR DESCRIPTION
- Added IfDefs around the interactive demo calls, as they weren't building on anything other than WebGL
- Called our DevRel Access Manager server to set a token.  If an unrecognized Pub/Sub key are used (usual behaviour if the customer is providing their own key) then, providing the customer has not also enabled access manager on their keyset, the app will still work.  When the customer moves to production and enables their own keyset's access manager, they need to also communicate to their own server to obtain a token.
- I struggled with what APIs are available in WebGL.  Looks like the C# HTTPClient is NOT available so I used UnityWebRequest instead
- Fixed issue where some assets did not have scripts associated with them on the intro and win screens
- Accidentally changed some of the whitespace which makes it a bit confusing to see all the changes, sorry about that, but it was only one file.